### PR TITLE
fix: include exaggeration in grayscale cache key

### DIFF
--- a/ilhmp/hillshade.py
+++ b/ilhmp/hillshade.py
@@ -101,7 +101,7 @@ def generate(
     if cache_dir is not None:
         cache_dir = Path(cache_dir)
         cache_dir.mkdir(parents=True, exist_ok=True)
-        gray_cache = cache_dir / f"{input_dem.stem}_gray.tif"
+        gray_cache = cache_dir / f"{input_dem.stem}_gray_z{exaggeration}.tif"
     else:
         gray_cache = None
 


### PR DESCRIPTION
## Problem

The grayscale hillshade cache filename was `{dem}_gray.tif` regardless of the `--exaggeration` value. When running multiple exaggeration levels with a shared `--cache-dir` (e.g. on an EC2 worker doing a comparison test), the first run's grayscale was silently reused for all subsequent exaggeration levels, producing byte-identical output tiles.

Found during the Kane County exaggeration test (dark+light × z=3/10/15) — all 6 variants came back identical.

## Fix

Include the exaggeration factor in the cache filename:

```python
# Before
gray_cache = cache_dir / f"{input_dem.stem}_gray.tif"

# After  
gray_cache = cache_dir / f"{input_dem.stem}_gray_z{exaggeration}.tif"
```

One-line change. Each exaggeration level now gets its own cached grayscale hillshade.

## Testing

Verified the bug by comparing mbtiles across exaggeration levels — SHA-identical tiles at every zoom level. After this fix, `ilhmp run kane --exaggeration 3` and `ilhmp run kane --exaggeration 10` with the same cache dir will produce `kane_dtm_4326_gray_z3.0.tif` and `kane_dtm_4326_gray_z10.0.tif` respectively.

Closes #13