### PR TITLE
fix: add BIGTIFF=YES to gdaldem hillshade output

### DIFF
--- a/ilhmp/hillshade.py
+++ b/ilhmp/hillshade.py
@@ -146,6 +146,7 @@ def _generate_grayscale(
         "-compute_edges",
         "-co", "COMPRESS=LZW",
         "-co", "TILED=YES",
+        "-co", "BIGTIFF=YES",
     ]
     
     result = subprocess.run(cmd, capture_output=True, text=True)


### PR DESCRIPTION
## Problem

`_generate_grayscale()` was missing the `BIGTIFF` creation option. When processing real Float32 DEMs from ISGS (e.g. Kane DTM 2008: 16GB, 80K×95K pixels), the gdaldem hillshade output exceeds the 4GB TIFF limit and fails with:

```
ERROR 1: TIFFAppendToStrip: Maximum TIFF file size exceeded. Use BIGTIFF=YES creation option.
```

This only manifests with the PR #14 fix (`_find_raster` now correctly picks the real Float32 DEM instead of the Byte hillshade viz). Previously, the wrong input was small enough to stay under 4GB.

## Fix

Add `-co BIGTIFF=YES` to the gdaldem command in `_generate_grayscale()`. All other GDAL calls in the codebase already use `BIGTIFF=IF_SAFER`.

## Context

Found during Kane County exaggeration test v3. Sequence of bugs:
1. PR #13: cache key missing exaggeration → identical tiles ✅ fixed
2. PR #14: `_find_raster` picks viz TIF over real DEM → empty tiles ✅ fixed  
3. **This PR**: real DEM exceeds 4GB TIFF limit → gdaldem crashes