### PR TITLE
fix: include exaggeration in styled hillshade cache path

### DIFF
--- a/ilhmp/cli.py
+++ b/ilhmp/cli.py
@@ -144,7 +144,7 @@ def run(
             console.print(f"[yellow]⏩[/yellow] Using cached: {dem_4326}")
 
     # Step 3: Hillshade
-    hs_path = intermediates_dir / f"{county.lower()}_hillshade_{style}.tif"
+    hs_path = intermediates_dir / f"{county.lower()}_hillshade_{style}_z{exaggeration}.tif"
     if not hs_path.exists() or force_recompute:
         if not json_out:
             console.print(f"[bold]Step 3/5:[/bold] Generating {style} hillshade...")


### PR DESCRIPTION
## Problem

`hs_path` in `cli.py` was `{county}_hillshade_{style}.tif` with no exaggeration factor. When running multiple exaggeration levels sharing a cache dir (e.g. `--exaggeration 3,10,15` via generate-aws.sh), the first run creates `kane_hillshade_dark.tif` and all subsequent exaggeration levels skip generation with "Using cached".

**Result:** All 6 variants produce identical tiles despite the grayscale cache key fix (PR #13) being correct at the module level — the styled hillshade never gets regenerated.

This is the 4th bug found during the Kane County exaggeration test.

## Fix

```python
# Before
hs_path = intermediates_dir / f"{county.lower()}_hillshade_{style}.tif"

# After
hs_path = intermediates_dir / f"{county.lower()}_hillshade_{style}_z{exaggeration}.tif"
```

## Bug chain (Kane exaggeration test)
1. PR #13 ✅ grayscale cache key missing exaggeration
2. PR #14 ✅ _find_raster picks viz TIF over real DEM
3. PR #15 ✅ BIGTIFF=YES missing from gdaldem
4. **This PR** — styled hillshade cache path missing exaggeration