### PR TITLE
cleanup: remove stale mchenry cool-elevation pending request

### DIFF
--- a/requests/mchenry-dtm-cool-elevation-autox-z10-16.yaml
+++ b/requests/mchenry-dtm-cool-elevation-autox-z10-16.yaml
@@ -1,7 +1,0 @@
-county: mchenry
-dem: dtm
-theme: cool-elevation
-exaggeration: auto
-zoom: "10-17"
-status: pending
-disk: 500


### PR DESCRIPTION
Generating McHenry locally instead. Removing stale pending request to prevent accidental cloud runs.