### PR TITLE
fix: deploy catalog.json to S3 on push to main

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'web/**'
       - 'scripts/ensure_public_status.py'
+      - 'requests/**'
   workflow_dispatch:
 
 permissions:
@@ -35,6 +36,8 @@ jobs:
             --cache-control "no-cache" --content-type "text/html"
           aws s3 cp web/status.html s3://exaggeratedrelief/status.html \
             --cache-control "no-cache" --content-type "text/html"
+          aws s3 cp web/catalog.json s3://exaggeratedrelief/catalog.json \
+            --cache-control "no-cache" --content-type "application/json"
           # Seed status/index.json if it doesn't exist
           aws s3 ls s3://exaggeratedrelief/status/index.json > /dev/null 2>&1 || \
             echo '{"updated_at":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","jobs":[]}' | \
@@ -51,7 +54,7 @@ jobs:
             echo "Invalidating CloudFront distribution $DIST_ID..."
             aws cloudfront create-invalidation \
               --distribution-id "$DIST_ID" \
-              --paths "/app.js" "/index.html" "/status.html"
+              --paths "/app.js" "/index.html" "/status.html" "/catalog.json"
             echo "✅ CloudFront cache invalidated"
           else
             echo "⚠️  No CloudFront distribution found — S3 is authoritative, propagation depends on TTL"


### PR DESCRIPTION
Adds catalog.json to the deploy step so it syncs automatically when PRs merge. Also triggers the workflow on requests/** changes (since ilhmp publish PRs update catalog.json via request files). Invalidates CloudFront /catalog.json as well.